### PR TITLE
Corrige erro de sintaxe markdown

### DIFF
--- a/docs/Iniciando com React/2-O que e React.md
+++ b/docs/Iniciando com React/2-O que e React.md
@@ -12,7 +12,7 @@ O **React** é uma biblioteca Javascript utilizada para construir interfaces de 
 
 Uma das principais características do React é o conceito de **componentes** que irá ser discutido ao longo do curso, porém, já te dando um pequeno _spoiler_, os componentes são uma das principais bases do React, eles existem para separar o código em pequenos arquivos que porventura serão reaproveitados em outras ocasiões da aplicação. Para escrever componentes é utilizado JSX, uma extensão de sintaxe para Javascript.
 
-Você pode consultar a documentação em PORTUGUÊS, traduzida pela comunidade, [aqui]{{https://pt-br.reactjs.org/)
+Você pode consultar a documentação em PORTUGUÊS, traduzida pela comunidade, [aqui](https://pt-br.reactjs.org/)
 
 Parece complicado, né? Mas não se assuste! Iremos entrar em detalhes em breve.
 


### PR DESCRIPTION
Há um erro de sintaxe markdown na parte do link da documentação traduzida do React no arquivo [2-O que e React.md](https://github.com/he4rt/react4noobs/blob/master/docs/Iniciando%20com%20React/2-O%20que%20e%20React.md)