### PR TITLE
fix: Link to React hooks md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 5. [Estados](./Iniciando%20com%20React/6-Estados.md)
 6. [Ciclo de Vida](./6-Ciclo-de-vida.md)
 7. [Manipulando Eventos](./Iniciando%20com%20React/7-Manipulando%20Eventos.md)
-8. [React Hooks](./Iniciando%20com%20React/7-React%20Hooks.md)
+8. [React Hooks](./Iniciando%20com%20React/8-React%20Hooks.md)
 
 ### Ferramentas de build
 


### PR DESCRIPTION
Correção do Link que leva para o MD da página do React Hooks.